### PR TITLE
Fix noops network

### DIFF
--- a/hyperledger/0.6/noops/4-peers.yml
+++ b/hyperledger/0.6/noops/4-peers.yml
@@ -62,4 +62,4 @@ services:
 #networks:
 #  default:
 #    external:
-#      name: fabric_pbft
+#      name: fabric_noops


### PR DESCRIPTION
When I setup the network with 4 peers in noops, un-commented the bottom networks section in the compose file and found `fabric_pbft`. Maybe it should be `fabric_noops` as well as other compose files.

The 4 peers network works with the name of `fabric_noops` :)