### PR TITLE
Fix error messages in make clean

### DIFF
--- a/hyperledger_fabric/v1.0.5/Makefile
+++ b/hyperledger_fabric/v1.0.5/Makefile
@@ -136,9 +136,9 @@ check: # Check shell scripts grammar
 
 clean: # clean up containers
 	@echo "Clean all HLF containers and fabric cc images"
-	@-docker ps -a | awk '{ print $1,$2 }' | grep "hyperledger/fabric" | awk '{print $1 }' | xargs -I {} docker rm -f {}
-	@-docker rm -f $$(docker ps -a | awk '$$2 ~ /dev-peer/ { print $$1}')
-	@-docker rmi $$(docker images | awk '$$1 ~ /dev-peer/ { print $$3}')
+	@-docker ps -a | awk '{ print $$1,$$2 }' | grep "hyperledger/fabric" | awk '{ print $$1 }' | xargs -r -I {} docker rm -f {}
+	@-docker ps -a | awk '$$2 ~ /dev-peer/ { print $$1 }' | xargs -r -I {} docker rm -f {}
+	@-docker images | awk '$$1 ~ /dev-peer/ { print $$3 }' | xargs -r -I {} docker rmi -f {}
 
 clean_env: # clean up environment
 	@echo "Clean all images and containers"


### PR DESCRIPTION
Hi Baohua,

I'm running Hyperledger Fabric based on your docker-compose files, and found some non-essential error messages. So let me suggest the fixes.

Thanks!
Naoya Horiguchi
___
"make clean" emits the following error message:

  root@ubuntu:~/docker-compose-files/hyperledger_fabric/v1.0.5# make clean
  Clean all HLF containers and fabric cc images
  awk: cmd. line:1: { print , }
  awk: cmd. line:1:         ^ syntax error
  awk: cmd. line:1: { print , }
  awk: cmd. line:1:           ^ syntax error
  awk: cmd. line:1: { print , }
  awk: cmd. line:1:            ^ unexpected newline or end of string

This is simply because $1 and $2 are not properly escaped.

And we have another messages like below:

  "docker rm" requires at least 1 argument(s).
  See 'docker rm --help'.

  Usage:  docker rm [OPTIONS] CONTAINER [CONTAINER...]

  Remove one or more containers
  Makefile:138: recipe for target 'clean' failed
  make: [clean] Error 1 (ignored)
  "docker rmi" requires at least 1 argument(s).
  See 'docker rmi --help'.

  Usage:  docker rmi [OPTIONS] IMAGE [IMAGE...]

  Remove one or more images
  Makefile:138: recipe for target 'clean' failed
  make: [clean] Error 1 (ignored)

If we have no target containers or images, we don't want to call docker
rm/rmi. xargs has -r option for this purpose, so let's turn it on.

Signed-off-by: Naoya Horiguchi <n-horiguchi@ah.jp.nec.com>