### PR TITLE
Update mongodb cluster config to use hostnames

### DIFF
--- a/mongo_cluster/docker-compose.yml
+++ b/mongo_cluster/docker-compose.yml
@@ -1,43 +1,25 @@
 # This will boot 4 containers: 3 mongo as a cluster, and 1 to issue mongo commands to others
 #
+version: "2.2"
+services:
+  mongo3:
+    image: mongo:3.2
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--replSet", "rs", "--rest", "--httpinterface" ]
 
-mongo3:
-  image: mongo:3.0
-  hostname: mongo3
-  expose:
-    - "27017"
-    - "28017"
-  restart: always
-  entrypoint: [ "/usr/bin/mongod", "--replSet", "rs", "--rest", "--httpinterface" ]
+  mongo2:
+    image: mongo:3.2
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--replSet", "rs", "--rest", "--httpinterface" ]
 
-mongo2:
-  image: mongo:3.0
-  hostname: mongo2
-  expose:
-    - "27017"
-    - "28017"
-  restart: always
-  entrypoint: [ "/usr/bin/mongod", "--replSet", "rs", "--rest", "--httpinterface" ]
+  mongo1:
+    image: mongo:3.0
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--replSet", "rs", "--rest", "--httpinterface" ]
 
-mongo1:
-  image: mongo:3.0
-  hostname: mongo1
-  expose:
-    - "27017"
-    - "28017"
-  links:
-    - mongo2:mongo2
-    - mongo3:mongo3
-  restart: always
-  entrypoint: [ "/usr/bin/mongod", "--replSet", "rs", "--rest", "--httpinterface" ]
-
-mongosetup:
-  image: mongo:3.0
-  links:
-    - mongo1:mongo1
-    - mongo2:mongo2
-    - mongo3:mongo3
-  volumes:
-    - ./scripts:/scripts
-  restart: always
-  entrypoint: [ "bash", "/scripts/mongosetup.sh" ]
+  mongosetup:
+    image: mongo:3.0
+    volumes:
+      - ./scripts:/scripts
+    restart: always
+    entrypoint: [ "bash", "/scripts/mongosetup.sh" ]

--- a/mongo_cluster/scripts/mongosetup.sh
+++ b/mongo_cluster/scripts/mongosetup.sh
@@ -1,39 +1,34 @@
 #!/bin/bash
-
-MONGODB1=`ping -c 1 mongo1 | head -1  | cut -d "(" -f 2 | cut -d ")" -f 1`
-MONGODB2=`ping -c 1 mongo2 | head -1  | cut -d "(" -f 2 | cut -d ")" -f 1`
-MONGODB3=`ping -c 1 mongo3 | head -1  | cut -d "(" -f 2 | cut -d ")" -f 1`
-
 echo "Waiting for startup.."
-until curl http://${MONGODB1}:28017/serverStatus\?text\=1 2>&1 | grep uptime | head -1; do
+until curl http://mongo1:28017/serverStatus\?text\=1 2>&1 | grep uptime | head -1; do
   printf '.'
   sleep 1
 done
 
-echo curl http://${MONGODB1}:28017/serverStatus\?text\=1 2>&1 | grep uptime | head -1
+echo curl http://mongo1:28017/serverStatus\?text\=1 2>&1 | grep uptime | head -1
 echo "Started.."
 
 sleep 10
 
 echo SETUP.sh time now: `date +"%T" `
-mongo --host ${MONGODB1}:27017 <<EOF
+mongo --host mongo1:27017 <<EOF
    var cfg = {
         "_id": "rs",
         "version": 1,
         "members": [
             {
                 "_id": 0,
-                "host": "${MONGODB1}:27017",
+                "host": "mongo1:27017",
                 "priority": 2
             },
             {
                 "_id": 1,
-                "host": "${MONGODB2}:27017",
+                "host": "mongo2:27017",
                 "priority": 0
             },
             {
                 "_id": 2,
-                "host": "${MONGODB3}:27017",
+                "host": "mongo3:27017",
                 "priority": 0
             }
         ]
@@ -43,4 +38,4 @@ mongo --host ${MONGODB1}:27017 <<EOF
     db.getMongo().setReadPref('nearest');
 EOF
 
-ping 127.0.0.1 > /dev/null
+tail -f /dev/null


### PR DESCRIPTION
When using the appropriate docker-compose file format, docker service names resolve to an IP via docker's internal container network DNS. This removes the odd `ping HOSTNAME` stripping to find the ip address.

Plus removes all of the unnecessary cruft from the compose file.